### PR TITLE
Update theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/even"]
 	path = themes/even
-	url = https://github.com/olOwOlo/hugo-theme-even
+	url = https://github.com/allthingsembedded/hugo-theme-even

--- a/config.toml
+++ b/config.toml
@@ -21,8 +21,6 @@ disqusShortname = ""      # disqus_shortname
 googleAnalytics = "UA-120967880-1"      # UA-XXXXXXXX-X
 copyright = ""            # default: author.name ↓
 
-[author]                  # essential
-  name = "Javier Alvarez"
 
 [sitemap]                 # essential
   changefreq = "weekly"
@@ -46,6 +44,7 @@ copyright = ""            # default: author.name ↓
   url = "/tags/"
 
 [params]
+  author = { name = "Javier Alvarez" }
   version = "4.x"           # Used to give a friendly message when you have an incompatible update
   debug = false             # If true, load `eruda.min.js`. See https://github.com/liriliri/eruda
 


### PR DESCRIPTION
The `even` theme is pretty old and unmaintained and as such it doesn't work well with recent releases of hugo. This fixes a couple of issues and forks it, but I'll try to find a better solution moving forward.